### PR TITLE
only add the event listener when the dropdown is on the page

### DIFF
--- a/app/assets/javascripts/event.js
+++ b/app/assets/javascripts/event.js
@@ -5,5 +5,7 @@ $(document).ready(function(){
         hf.value = sel.value;
     }
 
-    $("select[id=pet]")[0].addEventListener("change", setId, false);
+    if ($(".pet-select").length > 0) {
+        $("select[id=pet]")[0].addEventListener("change", setId, false);
+    }
 });


### PR DESCRIPTION
This was weird... I think the event.js is being included on every request after any of the event pages are requested.  There was an error showing up in the console.  This fixes it for now - albeit, not elegantly. 